### PR TITLE
Use mid-latitude cosine approximation for longitudinal distance.

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,10 @@ function add_dance(location, link, schedule, distance) {
 }
 
 function distance(lat, lng, ll) {
-  return Math.sqrt((lat-ll[0])*(lat-ll[0]) + (lng-ll[1])*(lng-ll[1]));
+  // Approximate a flat Earth at the average latitude.
+  dlat = lat - ll[0];
+  dlong = (lng - ll[1]) * Math.cos(0.5*(lat + ll[0]) * Math.PI/180.);
+  return Math.sqrt(dlat*dlat + dlong*dlong);
 }
 
 function add_more_link(zip, minimum_dances) {


### PR DESCRIPTION
The current distance metric makes east-west distances longer and north-south distances shorter than they should be. Here's the list of places where the resulting list changes, which is a significant number of them:

https://gist.github.com/yoz/0781d30b5172b3cda9d1
