### PR TITLE
Update dances.json: Mt. Airy PA third Saturdays is gender-free

### DIFF
--- a/dances.json
+++ b/dances.json
@@ -1420,6 +1420,7 @@
   {
     "annual_freq": 9,
     "city": "Mt. Airy PA",
+    "gender_free": true,
     "url": "http://www.thursdaycontra.com/ThirdSaturday.html",
     "weekdays": "Saturdays"
   },


### PR DESCRIPTION
Reference: https://3rdsaturday.thursdaycontra.com/

> Our Callers use gender-neutral terms