### PR TITLE
Update dances.json: add Philadelphia fourth Saturday

### DIFF
--- a/dances.json
+++ b/dances.json
@@ -1424,6 +1424,13 @@
     "weekdays": "Saturdays"
   },
   {
+    "annual_freq": 12,
+    "city": "Philadelphia PA",
+    "gender_free": true,
+    "url": "http://www.thursdaycontra.com/",
+    "weekdays": "Saturdays"
+  },
+  {
     "annual_freq": 10,
     "city": "Lancaster PA",
     "url": "https://www.lancastercontra.org/",


### PR DESCRIPTION
This is for the newish fourth Saturday contra series in Rittenhouse Square. It's run by PATMAD and doesn't have its own website or FB page at the moment, so I put in the same link as the Thursday dance.