### PR TITLE
Update the URL for Sheffield MA

### DIFF
--- a/dances.json
+++ b/dances.json
@@ -688,7 +688,7 @@
   {
     "annual_freq": 10,
     "city": "Sheffield MA",
-    "url": "http://sheffieldcontradance.wordpress.com/",
+    "url": "https://sheffieldcontra.com/",
     "weekdays": "Saturdays"
   },
   {

--- a/dances_locs.json
+++ b/dances_locs.json
@@ -919,7 +919,7 @@
     "city": "Sheffield MA",
     "lat": 42.11,
     "lng": -73.36,
-    "url": "http://sheffieldcontradance.wordpress.com/",
+    "url": "https://sheffieldcontra.com/",
     "weekdays": "Saturdays"
   },
   {


### PR DESCRIPTION
https://sheffieldcontradance.wordpress.com/ currently says:
> Please visit our new site, https://sheffieldcontra.com/ , for all
> updates from now on!