### PR TITLE
Add Melrose MA dance

### DIFF
--- a/dances.json
+++ b/dances.json
@@ -625,6 +625,12 @@
     "weekdays": "Sundays"
   },
   {
+    "annual_freq": 4,
+    "city": "Melrose MA",
+    "url": "https://dance.manystrings6.com/",
+    "weekdays": "Saturdays"
+  },
+  {
     "annual_freq": 12,
     "city": "Northampton MA",
     "gender_free": true,

--- a/dances_locs.json
+++ b/dances_locs.json
@@ -834,6 +834,14 @@
     "weekdays": "Sundays"
   },
   {
+    "annual_freq": 4,
+    "city": "Melrose MA",
+    "lat": 42.46,
+    "lng": -71.07,
+    "url": "https://dance.manystrings6.com/",
+    "weekdays": "Saturdays"
+  },
+  {
     "annual_freq": 12,
     "city": "Northampton MA",
     "gender_free": true,


### PR DESCRIPTION
I don't see anything on the website about a regular schedule, so I guessed the annual_freq and weekdays based on posts in https://www.facebook.com/groups/42189851366/ over the past year.

https://www.facebook.com/groups/42189851366/posts/10162318947996367/ 2026-01-24 4th Saturday

https://www.facebook.com/groups/42189851366/posts/10162658288806367/ 2026-04-18 3rd Saturday

https://www.facebook.com/groups/42189851366/posts/10162901413456367/ 2026-06-20 3rd Saturday

https://www.facebook.com/groups/42189851366/posts/10163016507566367/ 2026-07-18 3rd Saturday

I have no idea if all the dances were posted in that group though, so 4 might be a significant undercount.