### PR TITLE
Add Manchester CT dance

### DIFF
--- a/dances.json
+++ b/dances.json
@@ -297,6 +297,13 @@
     "ical": ["https://calendar.google.com/calendar/ical/7bff9929303685e90d4d3414fcfcc2437817ebc622616fd52dde043038622a50%40group.calendar.google.com/public/basic.ics"]
   },
   {
+    "annual_freq": 6,
+    "city": "Manchester CT",
+    "gender_free": true,
+    "url": "https://www.uuse.org/regular-events/gender-free-contra-dance",
+    "weekdays": "Saturdays"
+  },
+  {
     "annual_freq": 10,
     "city": "Arden DE",
     "gender_free": true,

--- a/dances_locs.json
+++ b/dances_locs.json
@@ -393,6 +393,15 @@
     "weekdays": "Sundays"
   },
   {
+    "annual_freq": 6,
+    "city": "Manchester CT",
+    "gender_free": true,
+    "lat": 41.78,
+    "lng": -72.52,
+    "url": "https://www.uuse.org/regular-events/gender-free-contra-dance",
+    "weekdays": "Saturdays"
+  },
+  {
     "annual_freq": 10,
     "city": "Arden DE",
     "gender_free": true,


### PR DESCRIPTION
I guessed the annual_freq and weekdays based on events listed at <https://www.facebook.com/UUSEast>. There were dances in March, June, and an upcoming one in September. If March was the first (no idea, just guessing), then that's 3 dances in 7 months. All were on a Saturday.

lat and lng are from
https://en.wikipedia.org/wiki/Manchester,_Connecticut