### PR TITLE
Remove Stafford CT

### DIFF
--- a/dances.json
+++ b/dances.json
@@ -283,12 +283,6 @@
     "weekdays": "Fridays"
   },
   {
-    "annual_freq": 9,
-    "city": "Stafford CT",
-    "url": "https://www.facebook.com/StaffordStomp/",
-    "weekdays": "Saturdays"
-  },
-  {
     "annual_freq": 20,
     "city": "New Haven CT",
     "gender_free": true,

--- a/dances_locs.json
+++ b/dances_locs.json
@@ -373,14 +373,6 @@
     "weekdays": "Fridays"
   },
   {
-    "annual_freq": 9,
-    "city": "Stafford CT",
-    "lat": 41.98,
-    "lng": -72.32,
-    "url": "https://www.facebook.com/StaffordStomp/",
-    "weekdays": "Saturdays"
-  },
-  {
     "annual_freq": 20,
     "city": "New Haven CT",
     "gender_free": true,


### PR DESCRIPTION
https://www.facebook.com/StaffordStomp/posts/pfbid0LPPGa9XNHUiQcswvjPYVo1qdUYitRLXMGtrnXgXBPTEfGgNwBVF1AuvMLE2boBZul (2024-05-29, from the facebook page linked here)

> The Stomp was the first time I tried building a barn dance community
> and it lasted seven years until we lost use of the hall.

https://www.facebook.com/groups/894246109361685/posts/1288368609949431/ (2026-09-02, from the person who I think was the organizer)

> Previously I organized The Stafford Stomp Barn Dance where our by line
> was "Building Community One Step at a Time"  We danced for several
> years but when Memorial Hall shut down, our dance community was soon
> gone.